### PR TITLE
fix rubocop offenses

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,5 @@
-source "https://supermarket.chef.io"
+source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook 'opentsdb-instance-test', :path => './test/fixtures/cookbooks/opentsdb-instance-test'
+cookbook 'opentsdb-instance-test', path: './test/fixtures/cookbooks/opentsdb-instance-test'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,7 +11,7 @@ Vagrant.configure('2') do |config|
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.
-  config.vm.box_url = "https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-14.04_provisionerless.box"
+  config.vm.box_url = 'https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-14.04_provisionerless.box'
 
   config.vm.define :bootstrap, primary: true do |guest|
     guest.vm.network :private_network, ip: '172.16.38.10'


### PR DESCRIPTION
because we like passing tests..

```
Inspecting 8 files
C...C...

Offenses:

Berksfile:1:8: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
source "https://supermarket.chef.io"
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Berksfile:5:36: C: Use the new Ruby 1.9 hash syntax.
cookbook 'opentsdb-instance-test', :path => './test/fixtures/cookbooks/opentsdb-instance-test'
                                   ^^^^^^^^
Vagrantfile:14:23: C: Prefer single-quoted strings when you don't need string interpolation or special symbols.
  config.vm.box_url = "https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-14.04_provisionerless.box"
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

8 files inspected, 3 offenses detected
```