### PR TITLE
Changed instance_name to instance in opentsdb_instance.rb library file.

### DIFF
--- a/libraries/opentsdb_instance.rb
+++ b/libraries/opentsdb_instance.rb
@@ -131,7 +131,7 @@ module OpentsdbCookbook
         notifying_block do
           # Install Packages
           prereq_pack
-          remote_file "#{new_resource.instance_name} :create opentsdb-#{new_resource.version}#{distro_ext}" do
+          remote_file "#{new_resource.instance} :create opentsdb-#{new_resource.version}#{distro_ext}" do
             path "/tmp/opentsdb-#{new_resource.version}#{distro_ext}"
             source "https://github.com/OpenTSDB/opentsdb/releases/download/v#{new_resource.version}/opentsdb-#{new_resource.version}#{distro_ext}"
             action :create
@@ -156,7 +156,7 @@ module OpentsdbCookbook
 
           # Create opentsdb config file
           %w(opentsdb.conf logback.xml).each do |t|
-            template "#{new_resource.instance_name} :create #{new_resource.config_dir}/#{t}" do
+            template "#{new_resource.instance} :create #{new_resource.config_dir}/#{t}" do
               source "#{new_resource.source_dir}/#{t}.erb"
               path "#{new_resource.config_dir}/#{t}"
               variables(config: new_resource)

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Anthony Caiafa'
 maintainer_email 'acaiafa1@bloomberg.net'
 description 'Application cookbook which installs and configures OpenTSDB.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.3'
+version '1.0.4'
 
 supports 'redhat', '>= 5.8'
 supports 'centos', '>= 5.8'


### PR DESCRIPTION
The cookbook didn't work because instance_name was no longer a valid attribute. Changing it to instance fixes the problem.