### PR TITLE
Allow user override, fix stray comma

### DIFF
--- a/libraries/opentsdb_instance.rb
+++ b/libraries/opentsdb_instance.rb
@@ -128,7 +128,7 @@ module OpentsdbCookbook
 
       # HBASE Options
       attribute(:hbase_client_retries_number, kind_of: String, default: '10')
-      attribute(:hbase_increments_buffer_size, kind_of: String, default: '65,535')
+      attribute(:hbase_increments_buffer_size, kind_of: String, default: '65535')
       attribute(:hbase_ipc_client_connection_idle_timeout, kind_of: String, default: '300')
       attribute(:hbase_ipc_client_socket_receiveBufferSize, kind_of: String)
       attribute(:hbase_ipc_client_socket_sendBufferSize, kind_of: String)

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Anthony Caiafa'
 maintainer_email 'acaiafa1@bloomberg.net'
 description 'Application cookbook which installs and configures OpenTSDB.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.1'
+version '1.1.2'
 
 supports 'redhat', '>= 5.8'
 supports 'centos', '>= 5.8'

--- a/templates/default/etc/init.d/opentsdb_debian
+++ b/templates/default/etc/init.d/opentsdb_debian
@@ -16,8 +16,8 @@
 
 PATH=/bin:/usr/bin:/sbin:/usr/sbin
 NAME=opentsdb
-TSD_USER=opentsdb
-TSD_GROUP=opentsdb
+TSD_USER=<% @options[:opentsdb_resource].user %>
+TSD_GROUP=<% @options[:opentsdb_resource].group %>
 DAEMON=/usr/share/opentsdb/bin/tsdb
 DAEMON_OPTS=tsd
 PID_FILE=/var/run/$NAME.pid

--- a/templates/default/etc/init.d/opentsdb_rhel.erb
+++ b/templates/default/etc/init.d/opentsdb_rhel.erb
@@ -35,7 +35,7 @@ MAX_OPEN_FILES=65535
 NAME=opentsdb
 PROG=/usr/bin/tsdb
 HOSTNAME=$(hostname --fqdn)
-USER=root
+USER=<% @options[:opentsdb_resource].user %>
 
 # Default directories
 LOG_DIR=/var/log/opentsdb


### PR DESCRIPTION
I didn't change the debian template because that one uses opentsdb use, whereas the library defaults the user to root. I can't reconcile this difference in a backwards compatible way. Any suggestions?