### PR TITLE
fix bug using the attribute hbase.security.authentication

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Anthony Caiafa'
 maintainer_email 'acaiafa1@bloomberg.net'
 description 'Application cookbook which installs and configures OpenTSDB.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.9'
+version '1.1.10'
 
 supports 'redhat', '>= 5.8'
 supports 'centos', '>= 5.8'

--- a/templates/default/etc/opentsdb/opentsdb.conf.erb
+++ b/templates/default/etc/opentsdb/opentsdb.conf.erb
@@ -296,7 +296,7 @@ hbase.security.auth.94 = <%= @config.hbase_security_auth_94 %>
 hbase.security.auth.enable = <%= @config.hbase_security_auth_enable %>
 <% if @config.hbase_security_authentication %>
 # The type of authentication required for the HBase cluster. May be kerberos or simple.
-hbase.security.authentication = <%= @config.config.hbase_security_authentication %>
+hbase.security.authentication = <%= @config.hbase_security_authentication %>
 <% end %>
 <% if @config.hbase_security_simple_username %>
 # The user name for authenticating against an HBase cluster with simple authentication. (Not recommended)


### PR DESCRIPTION
There is a [bug in the template using the attribute hbase.security.authentication](https://github.com/acaiafa/opentsdb-cookbook/blob/master/templates/default/etc/opentsdb/opentsdb.conf.erb#L299).
