### PR TITLE
Enable specifying alternate package source

### DIFF
--- a/libraries/opentsdb_instance.rb
+++ b/libraries/opentsdb_instance.rb
@@ -201,7 +201,11 @@ module OpentsdbCookbook
           prereq_pack
           remote_file "#{new_resource.instance} :create opentsdb-#{new_resource.version}#{distro_ext}" do
             path "/tmp/opentsdb-#{new_resource.version}#{distro_ext}"
-            source "https://github.com/OpenTSDB/opentsdb/releases/download/v#{new_resource.version}/opentsdb-#{new_resource.version}#{distro_ext}"
+            if new_resource.package_url
+              source "#{new_resource.package_url}/opentsdb-#{new_resource.version}#{distro_ext}"
+            else
+              source "https://github.com/OpenTSDB/opentsdb/releases/download/v#{new_resource.version}/opentsdb-#{new_resource.version}#{distro_ext}"
+            end
             action :create
           end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Anthony Caiafa'
 maintainer_email 'acaiafa1@bloomberg.net'
 description 'Application cookbook which installs and configures OpenTSDB.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.10'
+version '1.1.11'
 
 supports 'redhat', '>= 5.8'
 supports 'centos', '>= 5.8'


### PR DESCRIPTION
Use an alternate source via the [package_url](https://github.com/acaiafa/opentsdb-cookbook/blob/master/libraries/opentsdb_instance.rb#L32) attribute if set, otherwise pull from github.com/opentsdb/opentsdb by default.