### PR TITLE
Add support for tsd.rollups

### DIFF
--- a/libraries/opentsdb_instance.rb
+++ b/libraries/opentsdb_instance.rb
@@ -174,6 +174,13 @@ module OpentsdbCookbook
       attribute(:logback_level, kind_of: String, default: 'INFO')
       attribute(:logback_stdout_flag, kind_of: [TrueClass, FalseClass], default: false)
 
+      # Rollup Parameters
+      attribute(:rollups_enable, kind_of: [TrueClass, FalseClass])
+      attribute(:rollups_tag_raw, kind_of: [TrueClass, FalseClass])
+      attribute(:rollups_agg_tag_key, kind_of: String)
+      attribute(:rollups_raw_agg_tag_value, kind_of: String)
+      attribute(:rollups_block_derived, kind_of: [TrueClass, FalseClass])
+
       # JVM Arg Option
       attribute(:jvm_args, kind_of: [NilClass, String], default: nil)
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Anthony Caiafa'
 maintainer_email 'acaiafa1@bloomberg.net'
 description 'Application cookbook which installs and configures OpenTSDB.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.11'
+version '1.1.12'
 
 supports 'redhat', '>= 5.8'
 supports 'centos', '>= 5.8'

--- a/templates/default/etc/opentsdb/opentsdb.conf.erb
+++ b/templates/default/etc/opentsdb/opentsdb.conf.erb
@@ -319,3 +319,24 @@ hbase.zookeeper.session.timeout = <%= @config.hbase_zookeeper_session_timeout %>
 # Path under which the znode for the -ROOT- region is located
 hbase.zookeeper.znode.parent = <%= @config.hbase_zookeeper_znode_parent %>
 
+# --------- ROLLUP Options (Since 2.4) ----------
+<% if @config.rollups_enable %>
+# Whether or not to enable rollup and pre-aggregation storage and writing. 
+tsd.rollups.enable = <%= @config.rollups_enable %>
+<% end %>
+<% if @config.rollups_tag_raw %>
+# Whether or not to tag non-rolled-up and non-pre-aggregated values.
+tsd.rollups.tag_raw = <%= @config.rollups_tag_raw %>
+<% end %>
+<% if @config.rollups_agg_tag_key %>
+# A special key to tag pre-aggregated data with when writing to storage.
+tsd.rollups.agg_tag_key = <%= @config.rollups_agg_tag_key %>
+<% end %>
+<% if @config.rollups_raw_agg_tag_value %>
+# A special tag value to non-rolled-up and non-pre-aggregated data when writing to storage.
+tsd.rollups.raw_agg_tag_value = <%= @config.rollups_raw_agg_tag_value %>
+<% end %>
+<% if @config.rollups_block_derived %>
+# Whether or not to block storing derived aggregations such as AVG and DEV.
+tsd.rollups.block_derived = <%= @config.rollups_block_derived %>
+<% end %>


### PR DESCRIPTION
Adding support for `tsd.rollups` which is new since OpenTSDB 2.4. Just a note: didnt specify any defaults so that these settings will only be set when explicitly adding the attributes, as its not implemented in previous versions.