### PR TITLE
Fix template typos

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer 'Anthony Caiafa'
 maintainer_email 'acaiafa1@bloomberg.net'
 description 'Application cookbook which installs and configures OpenTSDB.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.1.13'
+version '1.1.14'
 
 supports 'redhat', '>= 5.8'
 supports 'centos', '>= 5.8'

--- a/templates/default/etc/opentsdb/opentsdb.conf.erb
+++ b/templates/default/etc/opentsdb/opentsdb.conf.erb
@@ -24,7 +24,7 @@ tsd.network.reuseaddress = <%= @config.network_reuseaddress %>
 
 # Number of worker threads dedicated to Netty, defaults to # of CPUs * 2
 <% if @config.network_worker_threads %>
-tsd.network.worker_threads = <%= @conifg.network_worker_threads %>
+tsd.network.worker_threads = <%= @config.network_worker_threads %>
 <% else %>
 #tsd.network.worker_threads = 8
 <% end %>
@@ -123,7 +123,7 @@ tsd.core.storage_exception_handler.enable = <%= @config.core_storage_exception_h
 
 <% if @config.core_storage_exception_handler_plugin %>
 # The full class name of the storage exception handler plugin you wish to use.
-tsd.core.storage_exception_handler.plugin = <%= @core_storage_exception_handler_plugin %>
+tsd.core.storage_exception_handler.plugin = <%= @config.core_storage_exception_handler_plugin %>
 <% end %>
 
 # --------- STORAGE ----------


### PR DESCRIPTION
Discovered this when I tried to use the storage handler plugin. Looked through the template and these were the only 2.