### PR TITLE
Add systemd service for platforms with systemd

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,6 +6,12 @@ provisioner:
   name: chef_zero
 
 platforms:
+  - name: ubuntu-16.04
+    run_list:
+      - recipe[apt::default]
+  - name: debian-8.7
+    run_list:
+      - recipe[apt::default]
   - name: ubuntu-14.04
     run_list:
       - recipe[apt::default]

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -5,7 +5,8 @@ module OpentsdbCookbook
     include Chef::DSL::IncludeRecipe
 
     def distro_ext
-      case node.platform_family
+      platform_family = node.attribute?('platform_family') ? node['platform_family'] : node['platform_version']
+      case platform_family
       when 'debian'
         '_all.deb'
       when 'rhel'
@@ -15,7 +16,8 @@ module OpentsdbCookbook
 
     def prereq_pack
       # RHEL world neds gnuplot
-      if node.platform_family == 'rhel'
+      platform_family = node.attribute?('platform_family') ? node['platform_family'] : node['platform_version']
+      if platform_family.eql?('rhel')
         package 'gnuplot' do
           action :install
         end

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,6 +8,7 @@ version '1.1.14'
 supports 'redhat', '>= 5.8'
 supports 'centos', '>= 5.8'
 supports 'ubuntu', '>= 12.04'
+supports 'debian', '>= 8'
 
 depends 'java'
 depends 'poise', '~> 2.2'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -8,4 +8,6 @@ node.default['java']['jdk_version'] = '8'
 node.default['java']['accept_license_agreement'] = true
 include_recipe 'java::default'
 
-opentsdb_instance node['opentsdb']['service_name']
+opentsdb_instance node['opentsdb']['service_name'] do
+  java_home node['java']['java_home']
+end

--- a/templates/default/etc/init.d/opentsdb_debian.erb
+++ b/templates/default/etc/init.d/opentsdb_debian.erb
@@ -27,20 +27,7 @@ MAX_OPEN_FILES=65535
 
 . /lib/lsb/init-functions
 
-# The first existing directory is used for JAVA_HOME
-# (if JAVA_HOME is not defined in $DEFAULT)
-JDK_DIRS="/usr/lib/jvm/java-7-oracle /usr/lib/jvm/java-7-openjdk \
-   /usr/lib/jvm/java-7-openjdk-amd64/ /usr/lib/jvm/java-7-openjdk-i386/ \
-   /usr/lib/jvm/java-6-sun /usr/lib/jvm/java-6-openjdk \
-   /usr/lib/jvm/java-6-openjdk-amd64 /usr/lib/jvm/java-6-openjdk-i386 \
-   /usr/lib/jvm/default-java"
-
-# Look for the right JVM to use
-for jdir in $JDK_DIRS; do
-  if [ -r "$jdir/bin/java" -a -z "${JAVA_HOME}" ]; then
-    JAVA_HOME="$jdir"
-  fi
-done
+JAVA_HOME=<%= @options[:java_home] %>
 
 if [ -r /etc/default/opentsdb ]; then
     . /etc/default/opentsdb

--- a/templates/default/etc/systemd/opentsdb.service.erb
+++ b/templates/default/etc/systemd/opentsdb.service.erb
@@ -1,0 +1,14 @@
+[Unit]
+Description=OpenTSDB Service
+After=network.target
+
+[Service]
+PrivateTmp=yes
+LimitNOFILE=65536
+Environment=JAVA_HOME=<%= @options['java_home'] %>
+PIDFile=/var/run/<%= @options['opentsdb_resource'].instance %>.pid
+ExecStart=/usr/share/opentsdb/bin/tsdb tsd
+Restart=on-abort
+
+[Install]
+WantedBy=multi-user.target

--- a/test/fixtures/cookbooks/opentsdb-instance-test/recipes/default.rb
+++ b/test/fixtures/cookbooks/opentsdb-instance-test/recipes/default.rb
@@ -1,5 +1,7 @@
-case node.platform
-when 'ubuntu'
+platform_family = node.attribute?('platform_family') ? node['platform_family'] : node['platform_version']
+
+case platform_family
+when 'ubuntu', 'debian'
   pkg = 'openjdk-7-jre-headless'
 
   # run apt-get since well yeah
@@ -23,6 +25,7 @@ opentsdb_instance 'opentsdb-write' do
   port 4300
   jmx_port 10201
   mode 'rw'
+  java_home '/usr/lib/jvm/java-7-openjdk-amd64'
   logback_configfile "/etc/opentsdb/opentsdb-write_logback.xml"
   logback_level 'WARN'
   custom_plugin_options ({ 'opt1' => 123, 'opt2' => 'tst' })
@@ -33,6 +36,7 @@ opentsdb_instance 'opentsdb-read' do
   version '2.2.0'
   port 4400
   jmx_port 10202
+  java_home '/usr/lib/jvm/java-7-openjdk-amd64'
   mode 'ro'
   logback_configfile "/etc/opentsdb/opentsdb-read_logback.xml"
   logback_level 'WARN'


### PR DESCRIPTION
The opentsdb_instance resource was only providing support to sysvinit
system.

This commit adds a systemd based service unit template for newer debian
and ubuntu systems. There is also a new java_home attribute to the
resource to set the JAVA_HOME env in the service definitions.

It has been tested against Chef 13.